### PR TITLE
Add auto GN detection for Ethernet and 802.11p+LLC/SNAP support

### DIFF
--- a/replay/gui_utils.py
+++ b/replay/gui_utils.py
@@ -9,13 +9,12 @@ from visualizer import Visualizer
 from scapy.all import *
 import asn1tools as asn
 from typing import Any
-from utils import filter_by_start_time, STANDARD_OBJECT_LENGTH, BUMPER_TO_SENSOR_DISTANCE
+from utils import find_gn_payload_offset, filter_by_start_time, STANDARD_OBJECT_LENGTH, BUMPER_TO_SENSOR_DISTANCE
 
 MAP_OPENED = False
 BTP_LOW = 40
 BTP_HIGH = 44
 BTP_PORT_HIGH = 2
-ETHER_LENGTH = 14
 
 CONVERSION_CONSTANT = 1e7
 PERCEIVED_OBJ_CONT_IDX = 5
@@ -88,7 +87,10 @@ def pcap_gui(pcap_filename: str, start_time: int, end_time: int, server_ip: str,
                     # print("Trying to sleep for a negative time, thus not sleeping: ", variable_delta_us_factor / 1e3)
                     pass
 
-                data = raw(pkt)[ETHER_LENGTH:]
+                gn_offset = find_gn_payload_offset(raw(pkt))
+                if gn_offset < 0:
+                    continue
+                data = raw(pkt)[gn_offset:]
                 btp = data[BTP_LOW: BTP_HIGH]
                 port = int.from_bytes(btp[:BTP_PORT_HIGH], byteorder="big")
                 _, ego_lon, _ = visualizer.get_ego_position()

--- a/replay/gui_utils.py
+++ b/replay/gui_utils.py
@@ -89,6 +89,7 @@ def pcap_gui(pcap_filename: str, start_time: int, end_time: int, server_ip: str,
 
                 gn_offset = find_gn_payload_offset(raw(pkt))
                 if gn_offset < 0:
+                    # best-effort: skip non-V2X packets silently to avoid log spam
                     continue
                 data = raw(pkt)[gn_offset:]
                 btp = data[BTP_LOW: BTP_HIGH]

--- a/replay/pcap_utils.py
+++ b/replay/pcap_utils.py
@@ -9,11 +9,11 @@ from scapy.utils import rdpcap, wrpcap
 from scapy.packet import raw
 from scapy.layers.l2 import Ether
 from threading import BrokenBarrierError
+from utils import find_gn_payload_offset
 
 # Normal packet (without security layer) constants
 GEONET_LENGTH = 40
 BASICHEADER = 4
-ETHER_LENGTH = 14
 GEONET_TS_LOW = 20
 GEONET_TS_HIGH = 24
 BTP_LOW = 40
@@ -220,10 +220,12 @@ def write_pcap(barrier: Any, stop_event: Any, input_filename: str, interface: st
             if update_datetime:
                 raw_part = None
                 try:
-                    # Extract the Ethernet II part
-                    ether_part = raw(pkt)[:ETHER_LENGTH]
+                    gn_offset = find_gn_payload_offset(raw(pkt))
+                    assert gn_offset >= 0, "GeoNetworking Ethertype not found in the packet, cannot update datetime"
+                    # Extract the header part
+                    header_part = raw(pkt)[:gn_offset]
                     # Take the rest ot the packet
-                    data = raw(pkt)[ETHER_LENGTH:]
+                    data = raw(pkt)[gn_offset:]
                     # Check if the security layer is active
                     security_enabled = False if data[:1] == b'\x11' else True
                     # Set the fields for pkt reconstruction to None to check if they will be filled properly
@@ -250,8 +252,8 @@ def write_pcap(barrier: Any, stop_event: Any, input_filename: str, interface: st
                         from security_utils.Security import Security
                         security = Security()
                         pack = raw(pkt)
-                        EtherAndBasic = pack[:ETHER_LENGTH+BASICHEADER]
-                        DecodedPacket = SECURITY.decode("Ieee1609Dot2Data", pack[18:])
+                        EtherAndBasic = pack[:gn_offset + BASICHEADER]
+                        DecodedPacket = SECURITY.decode("Ieee1609Dot2Data", pack[gn_offset + BASICHEADER:])
                         payload_data = DecodedPacket['content'][1]['tbsData']['payload']['data']
                         payload_choice, UnsecuredData = payload_data['content']
                         Signer = DecodedPacket['content'][1]['signer'][0]  # header
@@ -428,8 +430,8 @@ def write_pcap(barrier: Any, stop_event: Any, input_filename: str, interface: st
                         # Build the new packet
                         raw_part = new_geonet + btp + mex_encoded
                         
-                        if ether_part and raw_part:
-                            new_pkt = ether_part + raw_part
+                        if header_part and raw_part:
+                            new_pkt = header_part + raw_part
                         if security_enabled:
                             # rebuild the security layer
                             new_payload = btp + mex_encoded
@@ -466,11 +468,16 @@ def write_pcap(barrier: Any, stop_event: Any, input_filename: str, interface: st
                 try:
                     sock.send(new_pkt)
                     if enable_amqp:
-                        # Send the packet to the AMQP broker (excluding first 14 bytes of any Ethernet II "dummy" header)
-                        properties = compute_properties(security_enabled, port, StationID)
-                        succ = amqp_sender.send_message(new_pkt[ETHER_LENGTH:], message_id=f"packet{i+1}", properties=properties)
-                        if not succ:
-                            print("ERROR on message sending to the AMQP broker!")
+                        # Send the GeoNetworking payload to the AMQP broker
+                        # Auto-detect offset to support both Ethernet II and 802.11+LLC/SNAP encapsulations
+                        gn_offset = find_gn_payload_offset(new_pkt)
+                        if gn_offset < 0:
+                            print(f"WARNING: GeoNetworking Ethertype (0x8947) not found in packet {i+1}, skipping AMQP send")
+                        else:
+                            properties = compute_properties(security_enabled, port, StationID)
+                            succ = amqp_sender.send_message(new_pkt[gn_offset:], message_id=f"packet{i+1}", properties=properties)
+                            if not succ:
+                                print("ERROR on message sending to the AMQP broker!")
                 except Exception as e:
                     print(f"Error: {e}")
     except Exception as e:

--- a/replay/pcap_utils.py
+++ b/replay/pcap_utils.py
@@ -221,7 +221,9 @@ def write_pcap(barrier: Any, stop_event: Any, input_filename: str, interface: st
                 raw_part = None
                 try:
                     gn_offset = find_gn_payload_offset(raw(pkt))
-                    assert gn_offset >= 0, "GeoNetworking Ethertype not found in the packet, cannot update datetime"
+                    if gn_offset < 0:
+                        print(f"ERROR: GeoNetworking Ethertype (0x8947) not found in packet {i+1}, dropping (cannot update datetime)")
+                        continue
                     # Extract the header part
                     header_part = raw(pkt)[:gn_offset]
                     # Take the rest ot the packet

--- a/replay/utils.py
+++ b/replay/utils.py
@@ -14,6 +14,8 @@ METERS_PER_DEGREE_LATITUDE = 111320
 SPEED_THRESHOLD = 15  # [m/s]
 AGE_THRESHOLD = 20  # [ms]
 
+# GeoNetworking Ethertype marker (used to find GN payload in any encapsulation)
+GN_ETHERTYPE = b'\x89\x47'
 
 def compare_floats(a: float, b: float) -> bool:
     return math.isclose(a, b, rel_tol=1e-8)
@@ -23,3 +25,17 @@ def filter_by_start_time(data, start_time: int) -> list:
     start_time_micseconds = start_time
     assert start_time_micseconds < data[-1]["timestamp"], "The start time is greater than the last timestamp in the file"
     return list(filter(lambda x: x["timestamp"] >= start_time_micseconds, data))
+
+def find_gn_payload_offset(raw_pkt: bytes) -> int:
+    """
+    Find the offset where the GeoNetworking payload starts in a raw packet.
+    Works with both Ethernet II (14-byte header) and 802.11 + LLC/SNAP (34-byte header)
+    by searching for the GeoNetworking Ethertype marker (0x8947).
+
+    Returns the byte offset right after the 0x8947 marker (i.e., the start of the GN Basic Header).
+    Returns -1 if the marker is not found.
+    """
+    idx = raw_pkt.find(GN_ETHERTYPE)
+    if idx >= 0:
+        return idx + 2  # skip the 2-byte Ethertype itself
+    return -1


### PR DESCRIPTION
This pull request refactors how the code locates the start of the GeoNetworking (GN) payload in network packets, making it robust to different link-layer encapsulations (Ethernet II and 802.11+LLC/SNAP). Instead of assuming a fixed header length, it now searches for the GN Ethertype marker (0x8947) to dynamically find the payload offset. This change improves compatibility, reliability, and maintainability. The main updates are in `replay/pcap_utils.py`, `replay/gui_utils.py`, and `replay/utils.py`.

**GeoNetworking payload offset detection:**

* Added a new utility function `find_gn_payload_offset` in `replay/utils.py` to locate the GN payload by searching for the Ethertype marker, supporting both Ethernet II and 802.11+LLC/SNAP encapsulations.
* Replaced all usages of the fixed `ETHER_LENGTH` offset with dynamic offset detection using `find_gn_payload_offset` in both `replay/pcap_utils.py` and `replay/gui_utils.py`, ensuring correct extraction of the GN payload regardless of encapsulation.

**Code simplification and error handling:**

* Removed the now-unnecessary `ETHER_LENGTH` constant from affected files.
* Improved error handling: packets without the GN Ethertype marker are now gracefully skipped (with error or warning messages where appropriate) instead of causing potential crashes or misparsing.

**Utility constants:**

* Introduced `GN_ETHERTYPE` constant in `replay/utils.py` to clearly define the Ethertype marker used for GN packets.